### PR TITLE
feat:彻底干掉对牢容器（20.04）的依赖；avbtool现在用只实现了本仓库所需功能的最小定制版avb_mini_signer（avbctl）代替，不再依赖Py2；通过使用7zip代替unzip确保更多zip压缩时可使用的高效算法（zstd，lzma2等）得到支持

### DIFF
--- a/.github/workflows/noavb.yml
+++ b/.github/workflows/noavb.yml
@@ -50,7 +50,12 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox
+        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        # install static 7zz used by the scripts instead of busybox unzip:
+        # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
+        # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
+        chmod +x main/setup-7zz.sh
+        ./main/setup-7zz.sh
         wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
         pip2 install pycryptodome
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"

--- a/.github/workflows/noavb.yml
+++ b/.github/workflows/noavb.yml
@@ -21,8 +21,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/catthehacker/ubuntu:runner-20.04
     steps:
     
     - name: Checkout
@@ -50,16 +48,16 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        sudo apt -y install build-essential openssl curl wget busybox xz-utils python3
         # install static 7zz used by the scripts instead of busybox unzip:
         # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
         # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
         chmod +x main/setup-7zz.sh
         ./main/setup-7zz.sh
-        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
-        pip2 install pycryptodome
+        # build avbctl, the static C replacement for the python2 avbtool
+        # (fetches mbedtls-3.6 and links it statically)
+        make -C main/avbctl
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"
-        curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
         curl -o magisk.apk -L $(curl -s https://api.github.com/repos/topjohnwu/Magisk/releases | grep -Po -m 1 '(?<=download_url\"\: \").*Magisk.*Magisk.*apk')
         wget https://raw.githubusercontent.com/magojohnji/magiskboot-linux/main/x86_64/magiskboot
         chmod +x magiskboot

--- a/.github/workflows/novab_v3.yml
+++ b/.github/workflows/novab_v3.yml
@@ -50,7 +50,12 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox
+        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        # install static 7zz used by the scripts instead of busybox unzip:
+        # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
+        # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
+        chmod +x main/setup-7zz.sh
+        ./main/setup-7zz.sh
         wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
         pip2 install pycryptodome
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"

--- a/.github/workflows/novab_v3.yml
+++ b/.github/workflows/novab_v3.yml
@@ -21,8 +21,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/catthehacker/ubuntu:runner-20.04
     steps:
     
     - name: Checkout
@@ -50,16 +48,16 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        sudo apt -y install build-essential openssl curl wget busybox xz-utils python3
         # install static 7zz used by the scripts instead of busybox unzip:
         # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
         # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
         chmod +x main/setup-7zz.sh
         ./main/setup-7zz.sh
-        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
-        pip2 install pycryptodome
+        # build avbctl, the static C replacement for the python2 avbtool
+        # (fetches mbedtls-3.6 and links it statically)
+        make -C main/avbctl
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"
-        curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
         curl -o magisk.apk -L $(curl -s https://api.github.com/repos/topjohnwu/Magisk/releases | grep -Po -m 1 '(?<=download_url\"\: \").*Magisk.*Magisk.*apk')
         wget https://raw.githubusercontent.com/magojohnji/magiskboot-linux/main/x86_64/magiskboot
         chmod +x magiskboot

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -50,7 +50,12 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox
+        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        # install static 7zz used by the scripts instead of busybox unzip:
+        # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
+        # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
+        chmod +x main/setup-7zz.sh
+        ./main/setup-7zz.sh
         wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
         pip2 install pycryptodome
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -21,8 +21,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/catthehacker/ubuntu:runner-20.04
     steps:
     
     - name: Checkout
@@ -50,16 +48,16 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        sudo apt -y install build-essential openssl curl wget busybox xz-utils python3
         # install static 7zz used by the scripts instead of busybox unzip:
         # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
         # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
         chmod +x main/setup-7zz.sh
         ./main/setup-7zz.sh
-        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
-        pip2 install pycryptodome
+        # build avbctl, the static C replacement for the python2 avbtool
+        # (fetches mbedtls-3.6 and links it statically)
+        make -C main/avbctl
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"
-        curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
         curl -o magisk.apk -L $(curl -s https://api.github.com/repos/topjohnwu/Magisk/releases | grep -Po -m 1 '(?<=download_url\"\: \").*Magisk.*Magisk.*apk')
         wget https://raw.githubusercontent.com/magojohnji/magiskboot-linux/main/x86_64/magiskboot
         chmod +x magiskboot

--- a/.github/workflows/run_v3.yml
+++ b/.github/workflows/run_v3.yml
@@ -50,7 +50,12 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox
+        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        # install static 7zz used by the scripts instead of busybox unzip:
+        # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
+        # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
+        chmod +x main/setup-7zz.sh
+        ./main/setup-7zz.sh
         wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
         pip2 install pycryptodome
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"

--- a/.github/workflows/run_v3.yml
+++ b/.github/workflows/run_v3.yml
@@ -21,8 +21,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/catthehacker/ubuntu:runner-20.04
     steps:
     
     - name: Checkout
@@ -50,16 +48,16 @@ jobs:
         ANTIROLL: "${{ github.event.inputs.antiroll }}"
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox xz-utils python3
+        sudo apt -y install build-essential openssl curl wget busybox xz-utils python3
         # install static 7zz used by the scripts instead of busybox unzip:
         # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
         # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
         chmod +x main/setup-7zz.sh
         ./main/setup-7zz.sh
-        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
-        pip2 install pycryptodome
+        # build avbctl, the static C replacement for the python2 avbtool
+        # (fetches mbedtls-3.6 and links it statically)
+        make -C main/avbctl
         curl -o original.zip -L "${{ github.event.inputs.ZIP_URL }}"
-        curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
         curl -o magisk.apk -L $(curl -s https://api.github.com/repos/topjohnwu/Magisk/releases | grep -Po -m 1 '(?<=download_url\"\: \").*Magisk.*Magisk.*apk')
         wget https://raw.githubusercontent.com/magojohnji/magiskboot-linux/main/x86_64/magiskboot
         chmod +x magiskboot

--- a/.github/workflows/sign-magisk.yml
+++ b/.github/workflows/sign-magisk.yml
@@ -51,7 +51,12 @@ jobs:
     - name: patch
       run: |
         sudo apt update
-        sudo apt -y install build-essential python2 openssl curl wget busybox
+        sudo apt -y install build-essential python2 openssl curl wget busybox xz-utils python3
+        # install static 7zz used below instead of busybox unzip:
+        # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
+        # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
+        chmod +x main/setup-7zz.sh
+        ./main/setup-7zz.sh
         wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
         pip2 install pycryptodome
         curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
@@ -64,7 +69,8 @@ jobs:
         mv main/sign_avb.sh work/
         chmod +x boot/*
         chmod +x work/*
-        busybox unzip -oq magisk.apk -d boot/zzz
+        # 7zz exit code 1 = warnings only (archive still fully extracted), tolerate it like unzip did
+        7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
         curl -o boot/boot.img -L "${{ github.event.inputs.IMG_URL }}"
         tar xzvf avbtool.tgz -C work/
         cp main/config/*.pem work/

--- a/.github/workflows/sign-magisk.yml
+++ b/.github/workflows/sign-magisk.yml
@@ -51,7 +51,7 @@ jobs:
     - name: patch
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox
+        sudo apt -y install build-essential python2 openssl curl wget busybox
         wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
         pip2 install pycryptodome
         curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"

--- a/.github/workflows/sign-magisk.yml
+++ b/.github/workflows/sign-magisk.yml
@@ -24,8 +24,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/catthehacker/ubuntu:runner-20.04
     steps:
     
     - name: Checkout
@@ -51,15 +49,15 @@ jobs:
     - name: patch
       run: |
         sudo apt update
-        sudo apt -y install build-essential python2 openssl curl wget busybox xz-utils python3
+        sudo apt -y install build-essential openssl curl wget busybox xz-utils python3
         # install static 7zz used below instead of busybox unzip:
         # latest official ip7z/7zip linux-x64 release (resolved via GitHub API),
         # falling back to the mcmilk/7-Zip-zstd nightly linux-clang-x64 build
         chmod +x main/setup-7zz.sh
         ./main/setup-7zz.sh
-        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
-        pip2 install pycryptodome
-        curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
+        # build avbctl, the static C replacement for the python2 avbtool
+        # (fetches mbedtls-3.6 and links it statically)
+        make -C main/avbctl
         curl -o magisk.apk -L $(curl -s https://api.github.com/repos/topjohnwu/Magisk/releases | grep -Po -m 1 '(?<=download_url\"\: \").*Magisk.*Magisk.*apk')
         wget https://raw.githubusercontent.com/magojohnji/magiskboot-linux/main/x86_64/magiskboot
         chmod +x magiskboot
@@ -72,13 +70,11 @@ jobs:
         # 7zz exit code 1 = warnings only (archive still fully extracted), tolerate it like unzip did
         7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
         curl -o boot/boot.img -L "${{ github.event.inputs.IMG_URL }}"
-        tar xzvf avbtool.tgz -C work/
+        cp main/avbctl/avbctl work/
         cp main/config/*.pem work/
         cp -f work/rsa4096_boot.pem work/rsa4096_dtb.pem
         cp -f work/rsa4096_boot.pem work/rsa4096_dtbo.pem
         if [ -d extra_key ]; then cp -f extra_key/*.pem work/; fi
-        sudo rm -f /usr/bin/python /usr/bin/python3.6 /usr/bin/python3.6m /usr/local/bin/python
-        sudo ln -sf /usr/bin/python2.7 /usr/bin/python
         cd boot
         ./boot_patch.sh ${{ github.event.inputs.PART_SIZE }}
         cd ../work

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -24,8 +24,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/catthehacker/ubuntu:runner-20.04
     steps:
     
     - name: Checkout
@@ -51,21 +49,19 @@ jobs:
     - name: patch
       run: |
         sudo apt update
-        sudo apt -y install build-essential python openssl curl wget busybox
-        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && sudo python2.7 get-pip.py
-        pip2 install pycryptodome
+        sudo apt -y install build-essential openssl curl wget busybox
         curl -o image.img -L "${{ github.event.inputs.IMG_URL }}"
-        curl -o avbtool.tgz -L "https://android.googlesource.com/platform/external/avb/+archive/refs/heads/pie-release.tar.gz"
         mkdir work
-        tar xzvf avbtool.tgz -C work/
+        # build avbctl, the static C replacement for the python2 avbtool
+        # (fetches mbedtls-3.6 and links it statically)
+        make -C main/avbctl
+        cp main/avbctl/avbctl work/
         mv main/sign_avb.sh work/
         chmod +x work/*
         cp main/config/*.pem work/
         cp -f work/rsa4096_boot.pem work/rsa4096_dtb.pem
         cp -f work/rsa4096_boot.pem work/rsa4096_dtbo.pem
         if [ -d extra_key ]; then cp -f extra_key/*.pem work/; fi
-        sudo rm -f /usr/bin/python /usr/bin/python3.6 /usr/bin/python3.6m /usr/local/bin/python
-        sudo ln -sf /usr/bin/python2.7 /usr/bin/python
         cd work
         ./sign_avb.sh ${{ github.event.inputs.PART_NAME }} ../image.img ../image.img ${{ github.event.inputs.PART_SIZE }}
 

--- a/avbctl/.gitignore
+++ b/avbctl/.gitignore
@@ -1,0 +1,4 @@
+/avbctl
+libmbedcrypto.a
+.objs/
+mbedtls/

--- a/avbctl/Makefile
+++ b/avbctl/Makefile
@@ -1,0 +1,54 @@
+# avbctl — static pie-avbtool-compatible AVB signer (fork of avb_mini_signer)
+#
+# Usage (from the repository root):   make -C avbctl
+# Requirements: gcc + make + git (mbedtls-3.6 is fetched once into ./mbedtls;
+# pre-vendor that directory to build fully offline).
+
+CC      ?= gcc
+CFLAGS  ?= -O2 -std=c99
+
+MBEDTLS_DIR := mbedtls
+MBEDTLS_SRC := aes.c asn1parse.c asn1write.c base64.c bignum.c bignum_core.c \
+               bignum_mod.c bignum_mod_raw.c cipher.c cipher_wrap.c \
+               constant_time.c md.c oid.c pem.c pk.c pkparse.c pk_wrap.c \
+               platform.c platform_util.c rsa.c rsa_alt_helpers.c sha256.c \
+               sha512.c
+
+CONFIG_FLAGS := -Imbedtls-config \
+                -DMBEDTLS_CONFIG_FILE='"avb_config.h"' \
+                -DMBEDTLS_SHA512_C
+
+all: avbctl
+
+$(MBEDTLS_DIR)/library/sha512.c:
+	git clone --depth 1 --branch mbedtls-3.6 \
+		https://github.com/Mbed-TLS/mbedtls.git $(MBEDTLS_DIR)
+
+libmbedcrypto.a: $(MBEDTLS_DIR)/library/sha512.c avbctl.c
+	@set -e; mkdir -p .objs; \
+	cd $(MBEDTLS_DIR)/library; \
+	for f in $(MBEDTLS_SRC); do \
+		echo "  CC mbedtls $$f"; \
+		$(CC) -c -std=c99 -O2 -fPIC -fvisibility=hidden \
+			-fdata-sections -ffunction-sections \
+			-I../../$(MBEDTLS_DIR)/include \
+			-I../../mbedtls-config \
+			-DMBEDTLS_CONFIG_FILE='"avb_config.h"' \
+			-DMBEDTLS_SHA512_C \
+			"$$f" -o "../../.objs/$$f.o" || exit 1; \
+	done; \
+	ar rcs ../../libmbedcrypto.a ../../.objs/*.o; \
+	echo "  AR libmbedcrypto.a"
+
+avbctl: avbctl.c libmbedcrypto.a
+	$(CC) $(CFLAGS) $(CONFIG_FLAGS) -I$(MBEDTLS_DIR)/include \
+		avbctl.c libmbedcrypto.a -o avbctl
+	@echo "built: avbctl/avbctl"
+
+clean:
+	rm -rf avbctl libmbedcrypto.a .objs
+
+distclean: clean
+	rm -rf $(MBEDTLS_DIR)
+
+.PHONY: all clean distclean

--- a/avbctl/README.md
+++ b/avbctl/README.md
@@ -1,0 +1,69 @@
+# avbctl
+
+A tiny, dependency-free (mbedTLS, statically linked) C re-implementation of
+the subset of AOSP **avbtool (pie-release)** that this repository needs —
+built to replace the python2 `avbtool` in the GitHub Actions jobs, so the
+signing toolchain no longer depends on python2.7 / the nested
+`runner-20.04` container.
+
+Forked from and heavily based on
+[avb_mini_signer](https://github.com/Manatsu0721/avb_mini_signer) by
+Manatsu0721 (Apache-2.0), with the following additions:
+
+| capability | avb_mini_signer | avbctl |
+| --- | --- | --- |
+| add_hash_footer | ✅ (embedded key only) | ✅ runtime `--key` PEM (PKCS#1/PKCS#8) |
+| algorithms | SHA256_RSA4096 only | SHA256/SHA512 × RSA2048/4096/8192 |
+| `--prop K:V` | ❌ | ✅ pie-format property descriptors |
+| `info_image` | ❌ | ✅ pie-compatible output (`sign_avb.sh` parses it) |
+| `make_vbmeta_image --chain_partition` | ❌ | ✅ pie-format chain descriptors |
+| key handling | compiled-in test key | key file argument (extra_key trees work) |
+
+## Byte-format policy
+
+The on-disk output intentionally **replicates avbtool from the Android 9
+`pie-release` branch** — the exact python2 avbtool the workflows used to
+download:
+
+- release string `avbtool 1.0.0`, required libavb version 1.0
+- property descriptor: TAG=0, 32-byte fixed part (two 64-bit length
+  fields), payload `key\0value\0`
+- hash descriptor: TAG=2, 132-byte fixed part (reserved-only tail, i.e.
+  flags=0 — byte-identical to the modern layout)
+- chain descriptor: TAG=4, 92-byte fixed part
+- `add_hash_footer` places the vbmeta blob directly after the
+  4096-aligned image (like pie), footer at the end of the partition, and
+  is idempotent (an existing footer is stripped first)
+
+## Usage
+
+```sh
+# build (fetches mbedtls-3.6 once)
+make -C avbctl
+
+# what sign_avb.sh does:
+avbctl info_image --image boot-signed.img
+avbctl add_hash_footer --image boot.img --partition_name boot \
+    --algorithm SHA256_RSA4096 --key rsa4096_boot.pem \
+    --partition_size 4194304 --prop com.android.build.boot.os_version:13
+
+# what the generated sign_vbmeta.sh does:
+avbctl make_vbmeta_image --algorithm SHA256_RSA4096 --key rsa4096_vbmeta.pem \
+    --chain_partition boot:1:keys/rsa4096_boot_pub.bin \
+    --padding_size 4096 --output vbmeta-sign-custom.img
+```
+
+## Verification performed (see dev log)
+
+- `add_hash_footer` output passes `avbtool verify_image` (footer + vbmeta
+  struct + per-partition hash cascade) — tested with SHA256_RSA4096 and
+  SHA256_RSA2048
+- `make_vbmeta_image --chain_partition` output: descriptor section and
+  embedded public key are **byte-identical** to modern avbtool's output
+  for the same arguments (only intended difference: release string /
+  required-version fields follow pie)
+- signatures independently verified with `openssl dgst -sha256 -verify`
+- property descriptors byte-checked against the pie `struct` formats
+  (`nbf` rounding, `key\0value\0` payload)
+- `info_image` output parses correctly with the exact `grep`/`sed`/`awk`
+  pipeline from `sign_avb.sh`

--- a/avbctl/avbctl.c
+++ b/avbctl/avbctl.c
@@ -1,0 +1,730 @@
+/*
+ * avbctl — a tiny, static, python-free re-implementation of the subset of
+ * AOSP "avbtool" (pie-release) that action_big_resign_with_magisk needs.
+ *
+ * Forked from and heavily based on avb_mini_signer by Manatsu0721
+ * (https://github.com/Manatsu0721/avb_mini_signer, Apache-2.0).
+ * Extended to support runtime PEM keys, multiple algorithms, --prop,
+ * info_image and make_vbmeta_image --chain_partition.
+ *
+ * The on-disk byte format intentionally replicates avbtool from the
+ * Android 9 "pie-release" branch (the python2 avbtool this repo used to
+ * ship into jobs):
+ *   - release string           "avbtool 1.0.0"
+ *   - required libavb version  1.0
+ *   - property descriptor      TAG=0, 32-byte fixed part (two 64-bit
+ *                              length fields), payload key\0value\0
+ *   - hash descriptor          TAG=2, 132-byte fixed part
+ *   - chain descriptor         TAG=4, 92-byte fixed part
+ *   - add_hash_footer places the vbmeta blob right after the (4096-aligned)
+ *     image, footer at the end of the partition
+ *
+ * Usage (drop-in for the calls made by sign_avb.sh / sign_vbmeta.sh):
+ *   avbctl info_image --image IMG
+ *   avbctl add_hash_footer --image IMG --partition_name NAME \
+ *       --algorithm SHA256_RSA4096 --key KEY.pem --partition_size N \
+ *       [--prop KEY:VALUE]...
+ *   avbctl make_vbmeta_image --algorithm SHA256_RSA4096 --key KEY.pem \
+ *       [--chain_partition NAME:ROLLER:pubkey.bin]... [--prop KEY:VALUE]... \
+ *       --padding_size N --output OUT.img
+ */
+
+#define _GNU_SOURCE
+#define MBEDTLS_ALLOW_PRIVATE_ACCESS
+#define MBEDTLS_CONFIG_FILE "avb_config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <time.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
+#include <mbedtls/bignum.h>
+
+#define PROG "avbctl"
+#define AVB_RELEASE_STRING "avbtool 1.0.0"
+
+#define AVB_FOOTER_MAGIC "AVBf"
+#define AVB_MAGIC        "AVB0"
+#define FOOTER_SIZE      64
+#define HEADER_SIZE      256
+#define ALIGNMENT        64
+#define BLOCK_SIZE       4096
+
+/* header field offsets (see AvbVBMetaImageHeader C struct) */
+#define H_LIBAVB_MAJOR     4
+#define H_LIBAVB_MINOR     8
+#define H_AUTH_SIZE       12
+#define H_AUX_SIZE        20
+#define H_ALGORITHM       28
+#define H_ROLLBACK_INDEX 112
+#define H_FLAGS           120
+#define H_RELEASE_STRING  128
+
+/* PKCS#1 v1.5 DigestInfo prefix (19 bytes) for SHA-256 / SHA-512 */
+static const uint8_t ASN1_SHA256[] = {
+    0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+    0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05,
+    0x00, 0x04, 0x20
+};
+static const uint8_t ASN1_SHA512[] = {
+    0x30, 0x51, 0x30, 0x0d, 0x06, 0x09, 0x60, 0x86,
+    0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x03, 0x05,
+    0x00, 0x04, 0x40
+};
+
+typedef struct {
+    const char *name;
+    uint32_t type;      /* AVB algorithm type as written into the header */
+    int hash_len;       /* 32 or 64 */
+    int sig_len;        /* 256/512/1024 */
+    const uint8_t *asn1;
+} alg_info_t;
+
+static const alg_info_t ALGS[] = {
+    { "SHA256_RSA2048", 1, 32,  256, ASN1_SHA256 },
+    { "SHA256_RSA4096", 2, 32,  512, ASN1_SHA256 },
+    { "SHA256_RSA8192", 3, 32, 1024, ASN1_SHA256 },
+    { "SHA512_RSA2048", 4, 64,  256, ASN1_SHA512 },
+    { "SHA512_RSA4096", 5, 64,  512, ASN1_SHA512 },
+    { "SHA512_RSA8192", 6, 64, 1024, ASN1_SHA512 },
+};
+
+typedef struct { uint8_t *buf; size_t len, cap; } buf_t;
+typedef struct { char *key; char *value; } prop_t;
+typedef struct { char *name; uint32_t rollback_location; char *pk_path; } chain_t;
+
+/* ---------- small helpers ---------- */
+
+static uint64_t round_up(uint64_t v, uint64_t a) { return (v + a - 1) & ~(a - 1); }
+
+static void put_u32_be(uint8_t *p, uint32_t v) {
+    p[0] = v >> 24; p[1] = v >> 16; p[2] = v >> 8; p[3] = v;
+}
+static void put_u64_be(uint8_t *p, uint64_t v) {
+    for (int i = 0; i < 8; i++) p[i] = (uint8_t)(v >> (56 - 8 * i));
+}
+static uint32_t get_u32_be(const uint8_t *p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+}
+static uint64_t get_u64_be(const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v = (v << 8) | p[i];
+    return v;
+}
+
+static void die(const char *msg) { fprintf(stderr, PROG ": %s\n", msg); exit(1); }
+static void die_errno(const char *msg) { fprintf(stderr, PROG ": %s: ", msg); perror(""); exit(1); }
+
+static void *xmalloc(size_t n) { void *p = malloc(n ? n : 1); if (!p) die("out of memory"); return p; }
+static void *xrealloc(void *p, size_t n) { p = realloc(p, n ? n : 1); if (!p) die("out of memory"); return p; }
+
+static uint8_t *read_file(const char *path, size_t *out_size) {
+    FILE *fp = fopen(path, "rb");
+    if (!fp) die_errno(path);
+    fseek(fp, 0, SEEK_END);
+    long sz = ftell(fp);
+    if (sz < 0) die_errno("ftell");
+    rewind(fp);
+    uint8_t *buf = xmalloc(sz);
+    if (sz && fread(buf, 1, sz, fp) != (size_t)sz) die_errno("fread");
+    fclose(fp);
+    *out_size = (size_t)sz;
+    return buf;
+}
+
+static void write_full(const char *path, const uint8_t *data, size_t len) {
+    FILE *fp = fopen(path, "wb");
+    if (!fp) die_errno(path);
+    if (len && fwrite(data, 1, len, fp) != len) die_errno("fwrite");
+    if (fclose(fp) != 0) die_errno("fclose");
+}
+
+static void write_zeros(FILE *fp, uint64_t n) {
+    static const uint8_t zeros[4096] = {0};
+    while (n) {
+        size_t chunk = n > sizeof(zeros) ? sizeof(zeros) : (size_t)n;
+        if (fwrite(zeros, 1, chunk, fp) != chunk) die_errno("fwrite");
+        n -= chunk;
+    }
+}
+
+/* growable buffer */
+static void buf_reserve(buf_t *b, size_t extra) {
+    if (b->len + extra > b->cap) {
+        size_t cap = b->cap ? b->cap * 2 : 4096;
+        while (cap < b->len + extra) cap *= 2;
+        b->cap = cap;
+        b->buf = xrealloc(b->buf, cap);
+    }
+}
+static void buf_put(buf_t *b, const void *d, size_t n) {
+    buf_reserve(b, n);
+    memcpy(b->buf + b->len, d, n);
+    b->len += n;
+}
+static void buf_put_u32(buf_t *b, uint32_t v) { uint8_t t[4]; put_u32_be(t, v); buf_put(b, t, 4); }
+static void buf_put_u64(buf_t *b, uint64_t v) { uint8_t t[8]; put_u64_be(t, v); buf_put(b, t, 8); }
+static void buf_pad_to(buf_t *b, size_t target) {
+    if (b->len >= target) return;
+    buf_reserve(b, target - b->len);
+    memset(b->buf + b->len, 0, target - b->len);
+    b->len = target;
+}
+
+/* RNG for mbedtls RSA blinding (blinding only; not security relevant) */
+static int simple_rng(void *ctx, unsigned char *out, size_t len) {
+    (void)ctx;
+    static unsigned int seed = 0;
+    if (seed == 0) seed = (unsigned int)((uintptr_t)&seed ^ (uintptr_t)time(NULL) ^ (unsigned)getpid());
+    for (size_t i = 0; i < len; i++) {
+        seed = seed * 1103515245U + 12345U;
+        out[i] = (unsigned char)(seed >> 16);
+    }
+    return 0;
+}
+
+static void random_bytes(uint8_t *out, size_t n) {
+    FILE *f = fopen("/dev/urandom", "rb");
+    if (!f || fread(out, 1, n, f) != n) {
+        if (f) fclose(f);
+        simple_rng(NULL, out, n); /* fallback, should never happen on CI */
+        return;
+    }
+    fclose(f);
+}
+
+/* ---------- crypto ---------- */
+
+static const alg_info_t *find_alg(const char *name) {
+    for (size_t i = 0; i < sizeof(ALGS) / sizeof(ALGS[0]); i++)
+        if (!strcmp(ALGS[i].name, name)) return &ALGS[i];
+    fprintf(stderr, PROG ": unknown algorithm '%s' (supported:", name);
+    for (size_t i = 0; i < sizeof(ALGS) / sizeof(ALGS[0]); i++)
+        fprintf(stderr, " %s", ALGS[i].name);
+    fprintf(stderr, ")\n");
+    exit(1);
+}
+
+static void load_key(const char *path, mbedtls_pk_context *pk) {
+    size_t len;
+    uint8_t *data = read_file(path, &len);
+    uint8_t *z = xmalloc(len + 1);
+    memcpy(z, data, len); z[len] = 0;
+    free(data);
+    mbedtls_pk_init(pk);
+    int ret = mbedtls_pk_parse_key(pk, z, len + 1, NULL, 0, simple_rng, NULL);
+    free(z);
+    if (ret != 0) { fprintf(stderr, PROG ": failed to parse key %s: -0x%04x\n", path, (unsigned)-ret); exit(1); }
+    if (mbedtls_pk_get_type(pk) != MBEDTLS_PK_RSA) die("key is not RSA");
+    mbedtls_rsa_context *rsa = mbedtls_pk_rsa(*pk);
+    if ((ret = mbedtls_rsa_complete(rsa)) != 0) { fprintf(stderr, PROG ": rsa_complete: -0x%04x\n", (unsigned)-ret); exit(1); }
+}
+
+/* raw PKCS#1 v1.5 signature, like avbtool (openssl rsautl -sign -raw over
+ * the padded digest block) */
+static int rsa_sign(const alg_info_t *alg, mbedtls_rsa_context *rsa,
+                    const uint8_t *block, uint8_t *sig) {
+    size_t k = mbedtls_rsa_get_len(rsa);
+    if (k != (size_t)alg->sig_len) {
+        fprintf(stderr, PROG ": key size (%zu bytes) does not match algorithm %s (%d bytes)\n",
+                k, alg->name, alg->sig_len);
+        return -1;
+    }
+    return mbedtls_rsa_private(rsa, simple_rng, NULL, block, sig) == 0 ? 0 : -1;
+}
+
+static void sha_digest(const alg_info_t *alg, const uint8_t *d1, size_t n1,
+                       const uint8_t *d2, size_t n2, uint8_t *out) {
+    if (alg->hash_len == 32) {
+        mbedtls_sha256_context c; mbedtls_sha256_init(&c); mbedtls_sha256_starts(&c, 0);
+        mbedtls_sha256_update(&c, d1, n1);
+        if (d2) mbedtls_sha256_update(&c, d2, n2);
+        mbedtls_sha256_finish(&c, out); mbedtls_sha256_free(&c);
+    } else {
+        mbedtls_sha512_context c; mbedtls_sha512_init(&c); mbedtls_sha512_starts(&c, 0);
+        mbedtls_sha512_update(&c, d1, n1);
+        if (d2) mbedtls_sha512_update(&c, d2, n2);
+        mbedtls_sha512_finish(&c, out); mbedtls_sha512_free(&c);
+    }
+}
+
+static void build_pkcs1_block(const alg_info_t *alg, const uint8_t *digest,
+                              size_t key_bytes, uint8_t *out) {
+    size_t ps_len = key_bytes - 3 - 19 - alg->hash_len;
+    out[0] = 0x00; out[1] = 0x01;
+    memset(out + 2, 0xff, ps_len);
+    out[2 + ps_len] = 0x00;
+    memcpy(out + 3 + ps_len, alg->asn1, 19);
+    memcpy(out + 3 + ps_len + 19, digest, alg->hash_len);
+}
+
+/* AVB public key blob: key_num_bits(4) n0inv(4) modulus rr */
+static void encode_avb_pubkey(const mbedtls_rsa_context *rsa, buf_t *out) {
+    const mbedtls_mpi *n = &rsa->N;
+    int bits = (int)mbedtls_mpi_bitlen(n);
+    int bits_rounded = 1;
+    while (bits_rounded < bits) bits_rounded <<= 1;
+    if (bits_rounded != (int)(rsa->len * 8)) {
+        fprintf(stderr, PROG ": key bits=%d not a power of two\n", bits);
+        exit(1);
+    }
+    int key_bytes = bits_rounded / 8;
+
+    uint8_t *mod = xmalloc(key_bytes);
+    memset(mod, 0, key_bytes);
+    mbedtls_mpi_write_binary(n, mod, key_bytes);
+    uint32_t n0 = ((uint32_t)mod[key_bytes-4] << 24) | ((uint32_t)mod[key_bytes-3] << 16) |
+                  ((uint32_t)mod[key_bytes-2] << 8) | (uint32_t)mod[key_bytes-1];
+    uint32_t inv = 1U;
+    for (int i = 0; i < 5; i++) inv = inv * (2 - n0 * inv);
+    uint32_t n0inv = 0U - inv;
+
+    mbedtls_mpi r, rr, two;
+    mbedtls_mpi_init(&r); mbedtls_mpi_init(&rr); mbedtls_mpi_init(&two);
+    mbedtls_mpi_lset(&two, 2);
+    mbedtls_mpi_set_bit(&r, bits_rounded, 1);
+    mbedtls_mpi_exp_mod(&rr, &r, &two, n, NULL);
+    uint8_t *rr_buf = xmalloc(key_bytes);
+    memset(rr_buf, 0, key_bytes);
+    mbedtls_mpi_write_binary(&rr, rr_buf, key_bytes);
+    mbedtls_mpi_free(&r); mbedtls_mpi_free(&rr); mbedtls_mpi_free(&two);
+
+    buf_put_u32(out, (uint32_t)bits_rounded);
+    buf_put_u32(out, n0inv);
+    buf_put(out, mod, key_bytes);
+    buf_put(out, rr_buf, key_bytes);
+    free(mod); free(rr_buf);
+}
+
+/* ---------- descriptors (pie formats) ---------- */
+
+/* property: TAG=0, fixed 32 bytes: tag Q, nbf Q, key_size Q, value_size Q */
+static void encode_prop_desc(buf_t *out, const char *key, const char *value) {
+    size_t klen = strlen(key), vlen = strlen(value);
+    size_t nbf = 32 + klen + vlen + 2 - 16;
+    size_t nbf_p = round_up(nbf, 8);
+    buf_put_u64(out, 0);
+    buf_put_u64(out, nbf_p);
+    buf_put_u64(out, klen);
+    buf_put_u64(out, vlen);
+    buf_put(out, key, klen);
+    uint8_t z = 0; buf_put(out, &z, 1);
+    buf_put(out, value, vlen);
+    buf_put(out, &z, 1);
+    buf_pad_to(out, out->len + (nbf_p - nbf));
+}
+
+/* hash: TAG=2, fixed 132 bytes */
+static void encode_hash_desc(buf_t *out, const char *partition_name,
+                             uint64_t image_size, const char *algo_name,
+                             const uint8_t *salt, size_t salt_len,
+                             const uint8_t *digest, size_t digest_len) {
+    size_t nlen = strlen(partition_name);
+    size_t nbf = 132 + nlen + salt_len + digest_len - 16;
+    size_t nbf_p = round_up(nbf, 8);
+    buf_put_u64(out, 2);
+    buf_put_u64(out, nbf_p);
+    buf_put_u64(out, image_size);
+    char algo[33]; memset(algo, 0, 33);
+    strncpy(algo, algo_name, 32);
+    buf_put(out, algo, 32);
+    buf_put_u32(out, (uint32_t)nlen);
+    buf_put_u32(out, (uint32_t)salt_len);
+    buf_put_u32(out, (uint32_t)digest_len);
+    uint8_t reserved[64]; memset(reserved, 0, 64);
+    buf_put(out, reserved, 64);          /* pie layout: reserved[64], no flags field */
+    buf_put(out, partition_name, nlen);
+    buf_put(out, salt, salt_len);
+    buf_put(out, digest, digest_len);
+    buf_pad_to(out, out->len + (nbf_p - nbf));
+}
+
+/* chain: TAG=4, fixed 92 bytes */
+static void encode_chain_desc(buf_t *out, const char *partition_name,
+                              uint32_t rollback_location,
+                              const uint8_t *pubkey, size_t pk_len) {
+    size_t nlen = strlen(partition_name);
+    size_t nbf = 92 + nlen + pk_len - 16;
+    size_t nbf_p = round_up(nbf, 8);
+    buf_put_u64(out, 4);
+    buf_put_u64(out, nbf_p);
+    buf_put_u32(out, rollback_location);
+    buf_put_u32(out, (uint32_t)nlen);
+    buf_put_u32(out, (uint32_t)pk_len);
+    uint8_t reserved[64]; memset(reserved, 0, 64);
+    buf_put(out, reserved, 64);
+    buf_put(out, partition_name, nlen);
+    buf_put(out, pubkey, pk_len);
+    buf_pad_to(out, out->len + (nbf_p - nbf));
+}
+
+/* ---------- vbmeta blob (shared) ---------- */
+
+/* builds header+auth+aux; the auth hash/signature cover header+aux */
+static void build_vbmeta_blob(const alg_info_t *alg, mbedtls_rsa_context *rsa,
+                              const buf_t *descs, uint64_t rollback_index,
+                              uint32_t flags, buf_t *out) {
+    buf_t pubkey = {0};
+    encode_avb_pubkey(rsa, &pubkey);
+
+    size_t desc_size = descs ? descs->len : 0;
+    size_t aux_padded = round_up(desc_size + pubkey.len, ALIGNMENT);
+    size_t auth_padded = round_up((size_t)alg->hash_len + alg->sig_len, ALIGNMENT);
+
+    uint8_t hdr[HEADER_SIZE]; memset(hdr, 0, sizeof(hdr));
+    memcpy(hdr, AVB_MAGIC, 4);
+    put_u32_be(hdr + H_LIBAVB_MAJOR, 1);
+    put_u32_be(hdr + H_LIBAVB_MINOR, 0);
+    put_u64_be(hdr + H_AUTH_SIZE, auth_padded);
+    put_u64_be(hdr + H_AUX_SIZE, aux_padded);
+    put_u32_be(hdr + H_ALGORITHM, alg->type);
+    put_u64_be(hdr + 32, 0);                          /* hash_offset */
+    put_u64_be(hdr + 40, alg->hash_len);              /* hash_size */
+    put_u64_be(hdr + 48, alg->hash_len);              /* signature_offset */
+    put_u64_be(hdr + 56, alg->sig_len);               /* signature_size */
+    put_u64_be(hdr + 64, desc_size);                  /* public_key_offset */
+    put_u64_be(hdr + 72, pubkey.len);                 /* public_key_size */
+    put_u64_be(hdr + 80, desc_size + pubkey.len);     /* public_key_metadata_offset */
+    put_u64_be(hdr + 88, 0);                          /* public_key_metadata_size */
+    put_u64_be(hdr + 96, 0);                          /* descriptors_offset */
+    put_u64_be(hdr + 104, desc_size);                 /* descriptors_size */
+    put_u64_be(hdr + H_ROLLBACK_INDEX, rollback_index);
+    put_u32_be(hdr + H_FLAGS, flags);
+    memcpy(hdr + H_RELEASE_STRING, AVB_RELEASE_STRING, strlen(AVB_RELEASE_STRING));
+
+    buf_t aux = {0};
+    if (desc_size) buf_put(&aux, descs->buf, desc_size);
+    buf_put(&aux, pubkey.buf, pubkey.len);
+    buf_pad_to(&aux, aux_padded);
+
+    uint8_t digest[64];
+    sha_digest(alg, hdr, HEADER_SIZE, aux.buf, aux.len, digest);
+    uint8_t *block = xmalloc((size_t)rsa->len);
+    build_pkcs1_block(alg, digest, rsa->len, block);
+    uint8_t *sig = xmalloc((size_t)alg->sig_len);
+    if (rsa_sign(alg, rsa, block, sig) != 0) die("RSA signing failed");
+
+    buf_put(out, hdr, HEADER_SIZE);
+    buf_put(out, digest, alg->hash_len);
+    buf_put(out, sig, alg->sig_len);
+    buf_pad_to(out, HEADER_SIZE + auth_padded);
+    buf_put(out, aux.buf, aux.len);
+
+    free(block); free(sig); free(pubkey.buf); free(aux.buf);
+}
+
+/* ---------- info_image ---------- */
+
+static void print_hex(const char *label, const uint8_t *d, size_t n) {
+    printf("%s", label);
+    for (size_t i = 0; i < n; i++) printf("%02x", d[i]);
+    printf("\n");
+}
+
+static int info_image_cmd(const char *path) {
+    size_t fsize;
+    uint8_t *img = read_file(path, &fsize);
+
+    const uint8_t *vbmeta = NULL;
+    const uint8_t *footer = NULL;
+
+    if (fsize >= FOOTER_SIZE &&
+        !memcmp(img + fsize - FOOTER_SIZE, AVB_FOOTER_MAGIC, 4)) {
+        footer = img + fsize - FOOTER_SIZE;
+        uint64_t off = get_u64_be(footer + 20);
+        if (off + HEADER_SIZE > fsize || memcmp(img + off, AVB_MAGIC, 4))
+            die("footer found but no vbmeta at recorded offset");
+        vbmeta = img + off;
+    } else if (fsize >= HEADER_SIZE && !memcmp(img, AVB_MAGIC, 4)) {
+        vbmeta = img; /* bare vbmeta image */
+    } else {
+        fprintf(stderr, PROG ": %s does not look like an AVB image\n", path);
+        return 1;
+    }
+
+    if (footer) {
+        printf("Footer version:           %u.%u\n",
+               get_u32_be(footer + 4), get_u32_be(footer + 8));
+        printf("Image size:               %llu bytes\n", (unsigned long long)fsize);
+        printf("Original image size:      %llu bytes\n",
+               (unsigned long long)get_u64_be(footer + 12));
+        printf("VBMeta offset:            %llu\n", (unsigned long long)get_u64_be(footer + 20));
+        printf("VBMeta size:              %llu bytes\n",
+               (unsigned long long)get_u64_be(footer + 28));
+        printf("--\n");
+    }
+
+    uint32_t alg_type = get_u32_be(vbmeta + H_ALGORITHM);
+    const alg_info_t *alg = NULL;
+    for (size_t i = 0; i < sizeof(ALGS) / sizeof(ALGS[0]); i++)
+        if (ALGS[i].type == alg_type) alg = &ALGS[i];
+    if (!alg) { fprintf(stderr, PROG ": unknown algorithm type %u\n", alg_type); return 1; }
+
+    char release[49]; memcpy(release, vbmeta + H_RELEASE_STRING, 48); release[48] = 0;
+    for (int i = 47; i >= 0 && release[i] == 0; i--) release[i] = 0; /* rstrip NULs (implicit) */
+
+    printf("Minimum libavb version:   %u.%u\n",
+           get_u32_be(vbmeta + H_LIBAVB_MAJOR), get_u32_be(vbmeta + H_LIBAVB_MINOR));
+    printf("Header Block:             %d bytes\n", HEADER_SIZE);
+    printf("Authentication Block:     %llu bytes\n", (unsigned long long)get_u64_be(vbmeta + H_AUTH_SIZE));
+    printf("Auxiliary Block:          %llu bytes\n", (unsigned long long)get_u64_be(vbmeta + H_AUX_SIZE));
+    printf("Algorithm:                %s\n", alg->name);
+    printf("Rollback Index:           %llu\n", (unsigned long long)get_u64_be(vbmeta + H_ROLLBACK_INDEX));
+    printf("Flags:                    %u\n", get_u32_be(vbmeta + H_FLAGS));
+    printf("Release String:           '%s'\n", release);
+
+    printf("Descriptors:\n");
+    uint64_t auth_sz = get_u64_be(vbmeta + H_AUTH_SIZE);
+    const uint8_t *d = vbmeta + HEADER_SIZE + auth_sz + get_u64_be(vbmeta + 96);
+    uint64_t desc_sz = get_u64_be(vbmeta + 104);
+    size_t printed = 0;
+    uint64_t o = 0;
+    while (o + 16 <= desc_sz) {
+        uint64_t tag = get_u64_be(d + o);
+        uint64_t nbf = get_u64_be(d + o + 8);
+        if (o + 16 + nbf > desc_sz) { printf("    (truncated descriptor)\n"); break; }
+        const uint8_t *fixed = d + o + 16;
+        if (tag == 0) { /* property */
+            uint64_t ks = get_u64_be(fixed);
+            uint64_t vs = get_u64_be(fixed + 8);
+            const uint8_t *kv = fixed + 16;
+            printf("    Prop: %.*s -> '%.*s'\n", (int)ks, kv, (int)vs, kv + ks + 1);
+        } else if (tag == 2) { /* hash */
+            uint64_t isz = get_u64_be(fixed);
+            char algo[33]; memcpy(algo, fixed + 8, 32); algo[32] = 0;
+            uint32_t nlen = get_u32_be(fixed + 40);
+            uint32_t slen = get_u32_be(fixed + 44);
+            uint32_t dlen = get_u32_be(fixed + 48);
+            const uint8_t *payload = fixed + 116;
+            printf("    Hash descriptor:\n");
+            printf("      Image Size:            %llu bytes\n", (unsigned long long)isz);
+            printf("      Hash Algorithm:        %s\n", algo);
+            printf("      Partition Name:        %.*s\n", (int)nlen, payload);
+            print_hex("      Salt:                  ", payload + nlen, slen);
+            print_hex("      Digest:                ", payload + nlen + slen, dlen);
+        } else if (tag == 4) { /* chain partition */
+            uint32_t rloc = get_u32_be(fixed);
+            uint32_t nlen = get_u32_be(fixed + 4);
+            uint32_t plen = get_u32_be(fixed + 8);
+            const uint8_t *payload = fixed + 76;
+            printf("    Chain Partition descriptor:\n");
+            printf("      Partition Name:        %.*s\n", (int)nlen, payload);
+            printf("      Rollback Index Location: %u\n", rloc);
+            printf("      Public Key (blob size): %u bytes\n", plen);
+        } else if (tag == 1) {
+            printf("    Hashtree descriptor:\n");
+        } else if (tag == 3) {
+            printf("    Kernel CMD descriptor:\n");
+        } else {
+            printf("    (unknown descriptor tag %llu)\n", (unsigned long long)tag);
+        }
+        printed++;
+        o += 16 + nbf;
+    }
+    if (!printed) printf("    (none)\n");
+    free(img);
+    return 0;
+}
+
+/* ---------- add_hash_footer ---------- */
+
+static int add_hash_footer_cmd(const char *image_path, const char *part_name,
+                               const alg_info_t *alg, const char *key_path,
+                               uint64_t partition_size,
+                               prop_t *props, size_t nprops) {
+    mbedtls_pk_context pk;
+    load_key(key_path, &pk);
+    mbedtls_rsa_context *rsa = mbedtls_pk_rsa(pk);
+
+    size_t fsize;
+    uint8_t *img = read_file(image_path, &fsize);
+
+    /* idempotent: strip existing footer (avbtool behaviour) */
+    if (fsize >= FOOTER_SIZE &&
+        !memcmp(img + fsize - FOOTER_SIZE, AVB_FOOTER_MAGIC, 4)) {
+        uint64_t orig = get_u64_be(img + fsize - FOOTER_SIZE + 12);
+        printf("Footer detected, truncating to original image size (%llu)\n",
+               (unsigned long long)orig);
+        fsize = orig;
+    }
+
+    if (partition_size == 0 || partition_size % BLOCK_SIZE != 0)
+        die("Partition size of 0 or not a multiple of image block size.");
+
+    uint8_t salt[32];
+    random_bytes(salt, 32);
+    uint8_t digest[64];
+    sha_digest(alg, salt, 32, img, fsize, digest);
+
+    /* descriptors: hash desc first, then props (avbtool order) */
+    buf_t descs = {0};
+    encode_hash_desc(&descs, part_name, fsize,
+                     alg->hash_len == 32 ? "sha256" : "sha512",
+                     salt, 32, digest, alg->hash_len);
+    for (size_t i = 0; i < nprops; i++)
+        encode_prop_desc(&descs, props[i].key, props[i].value);
+
+    buf_t blob = {0};
+    build_vbmeta_blob(alg, rsa, &descs, 0, 0, &blob);
+
+    /* placement, exactly like avbtool: image padded to block size, vbmeta
+     * appended there, zero pad, footer at partition end */
+    uint64_t image_padded = round_up(fsize, BLOCK_SIZE);
+    uint64_t blob_padded = round_up(blob.len, BLOCK_SIZE);
+    if (image_padded + blob_padded + FOOTER_SIZE > partition_size) {
+        fprintf(stderr,
+                PROG ": Image size of %llu does not fit in partition of %llu\n",
+                (unsigned long long)fsize, (unsigned long long)partition_size);
+        return 1;
+    }
+    uint64_t vbmeta_offset = image_padded;
+
+    FILE *fp = fopen(image_path, "wb");
+    if (!fp) die_errno(image_path);
+    if (fsize && fwrite(img, 1, fsize, fp) != fsize) die_errno("fwrite");
+    write_zeros(fp, vbmeta_offset - fsize);
+    if (fwrite(blob.buf, 1, blob.len, fp) != blob.len) die_errno("fwrite");
+    write_zeros(fp, (partition_size - FOOTER_SIZE) - (vbmeta_offset + blob.len));
+    uint8_t ftr[FOOTER_SIZE]; memset(ftr, 0, FOOTER_SIZE);
+    memcpy(ftr, AVB_FOOTER_MAGIC, 4);
+    put_u32_be(ftr + 4, 1);
+    put_u32_be(ftr + 8, 0);
+    put_u64_be(ftr + 12, fsize);
+    put_u64_be(ftr + 20, vbmeta_offset);
+    put_u64_be(ftr + 28, blob.len);
+    if (fwrite(ftr, 1, FOOTER_SIZE, fp) != FOOTER_SIZE) die_errno("fwrite");
+    if (fclose(fp) != 0) die_errno("fclose");
+
+    printf("Successfully added hash footer to %s (vbmeta at %llu, %zu bytes)\n",
+           image_path, (unsigned long long)vbmeta_offset, blob.len);
+    free(img); free(descs.buf); free(blob.buf);
+    mbedtls_pk_free(&pk);
+    return 0;
+}
+
+/* ---------- make_vbmeta_image ---------- */
+
+static int make_vbmeta_cmd(const alg_info_t *alg, const char *key_path,
+                           chain_t *chains, size_t nchains,
+                           prop_t *props, size_t nprops,
+                           uint64_t padding_size, const char *output) {
+    mbedtls_pk_context pk;
+    load_key(key_path, &pk);
+    mbedtls_rsa_context *rsa = mbedtls_pk_rsa(pk);
+
+    buf_t descs = {0};
+    /* avbtool order: chain partitions first, then props */
+    for (size_t i = 0; i < nchains; i++) {
+        size_t pk_len;
+        uint8_t *pk_blob = read_file(chains[i].pk_path, &pk_len);
+        encode_chain_desc(&descs, chains[i].name, chains[i].rollback_location,
+                          pk_blob, pk_len);
+        printf("Adding chain partition %s:%u:%s (%zu bytes)\n",
+               chains[i].name, chains[i].rollback_location, chains[i].pk_path, pk_len);
+        free(pk_blob);
+    }
+    for (size_t i = 0; i < nprops; i++)
+        encode_prop_desc(&descs, props[i].key, props[i].value);
+
+    buf_t blob = {0};
+    build_vbmeta_blob(alg, rsa, &descs, 0, 0, &blob);
+
+    if (padding_size) {
+        if (blob.len > padding_size)
+            die("padding size is smaller than the vbmeta image");
+        buf_pad_to(&blob, padding_size);
+    }
+    write_full(output, blob.buf, blob.len);
+    printf("Successfully wrote %s (%zu bytes)\n", output, blob.len);
+    free(descs.buf); free(blob.buf);
+    mbedtls_pk_free(&pk);
+    return 0;
+}
+
+/* ---------- CLI ---------- */
+
+static void usage(void) {
+    fprintf(stderr,
+        PROG " - static pie-avbtool-compatible signer (fork of avb_mini_signer)\n\n"
+        "  avbctl info_image --image IMG\n"
+        "  avbctl add_hash_footer --image IMG --partition_name NAME\n"
+        "        --algorithm ALG --key KEY.pem --partition_size BYTES\n"
+        "        [--prop KEY:VALUE]...\n"
+        "  avbctl make_vbmeta_image --algorithm ALG --key KEY.pem\n"
+        "        [--chain_partition NAME:ROLLER:PUBKEY.bin]...\n"
+        "        [--prop KEY:VALUE]... [--padding_size BYTES] --output OUT\n\n"
+        "  algorithms: SHA256_RSA2048/4096/8192 SHA512_RSA2048/4096/8192\n");
+    exit(1);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) usage();
+    const char *cmd = argv[1];
+
+    const char *image = NULL, *part_name = NULL, *key = NULL, *output = NULL;
+    const char *algorithm = "SHA256_RSA4096";
+    uint64_t partition_size = 0, padding_size = 0;
+    prop_t props[64]; size_t nprops = 0;
+    chain_t chains[64]; size_t nchains = 0;
+
+    for (int i = 2; i < argc; i++) {
+        const char *a = argv[i];
+        #define NEXTVAL() ((i + 1 < argc) ? argv[++i] : (usage(), (const char *)NULL))
+        if (!strcmp(a, "--image")) image = NEXTVAL();
+        else if (!strcmp(a, "--partition_name")) part_name = NEXTVAL();
+        else if (!strcmp(a, "--algorithm")) algorithm = NEXTVAL();
+        else if (!strcmp(a, "--key")) key = NEXTVAL();
+        else if (!strcmp(a, "--partition_size")) partition_size = strtoull(NEXTVAL(), NULL, 0);
+        else if (!strcmp(a, "--padding_size")) padding_size = strtoull(NEXTVAL(), NULL, 0);
+        else if (!strcmp(a, "--output")) output = NEXTVAL();
+        else if (!strcmp(a, "--prop")) {
+            const char *kv = NEXTVAL();
+            const char *colon = strchr(kv, ':');
+            if (!colon) { fprintf(stderr, PROG ": malformed --prop %s\n", kv); return 1; }
+            if (nprops >= 64) die("too many --prop");
+            props[nprops].key = strndup(kv, colon - kv);
+            props[nprops].value = strdup(colon + 1);
+            nprops++;
+        }
+        else if (!strcmp(a, "--chain_partition")) {
+            const char *s = NEXTVAL();
+            char name[128]; unsigned loc; char pkpath[512];
+            if (sscanf(s, "%127[^:]:%u:%511s", name, &loc, pkpath) != 3) {
+                fprintf(stderr, PROG ": malformed --chain_partition %s\n", s);
+                return 1;
+            }
+            if (nchains >= 64) die("too many --chain_partition");
+            chains[nchains].name = strdup(name);
+            chains[nchains].rollback_location = loc;
+            chains[nchains].pk_path = strdup(pkpath);
+            nchains++;
+        }
+        else { fprintf(stderr, PROG ": unknown argument %s\n", a); usage(); }
+        #undef NEXTVAL
+    }
+
+    const alg_info_t *alg = find_alg(algorithm);
+
+    if (!strcmp(cmd, "info_image")) {
+        if (!image) die("--image is required");
+        return info_image_cmd(image);
+    }
+    if (!strcmp(cmd, "add_hash_footer")) {
+        if (!image || !part_name || !key || !partition_size) die(
+            "--image, --partition_name, --key and --partition_size are required");
+        return add_hash_footer_cmd(image, part_name, alg, key, partition_size,
+                                   props, nprops);
+    }
+    if (!strcmp(cmd, "make_vbmeta_image")) {
+        if (!key || !output) die("--key and --output are required");
+        return make_vbmeta_cmd(alg, key, chains, nchains, props, nprops,
+                               padding_size, output);
+    }
+    usage();
+    return 1;
+}

--- a/avbctl/mbedtls-config/avb_config.h
+++ b/avbctl/mbedtls-config/avb_config.h
@@ -1,0 +1,34 @@
+#ifndef AVB_MBEDTLS_CONFIG_H
+#define AVB_MBEDTLS_CONFIG_H
+
+/* Minimal mbedTLS config for AVB signing tool.
+ * Only enables: RSA, SHA256, PEM parsing, PK, BIGNUM, ASN1, BASE64, CIPHER, MD, OID */
+
+#define MBEDTLS_RSA_C
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_GENPRIME
+#define MBEDTLS_PKCS5_C
+#define MBEDTLS_PKCS12_C
+
+/* Platform */
+#define MBEDTLS_HAVE_ASM
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
+
+/* Remove features we don't need */
+/* #define MBEDTLS_X509_CRT_PARSE_C */
+/* #define MBEDTLS_X509_CRL_PARSE_C */
+/* #define MBEDTLS_X509_CSR_PARSE_C */
+/* #define MBEDTLS_SSL_TLS_C */
+
+#endif /* AVB_MBEDTLS_CONFIG_H */

--- a/noavb.sh
+++ b/noavb.sh
@@ -4,7 +4,8 @@ mkdir work
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
-tar xzvf avbtool.tgz -C vbmeta/
+cp main/avbctl/avbctl vbmeta/
+chmod +x vbmeta/avbctl
 mv work/vbmeta* vbmeta/keys/vbmeta.img
 7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
@@ -26,10 +27,10 @@ cd ../../vbmeta/keys/
 mv sign_vbmeta.sh ../
 mv padding.py ../
 cd ../..
+# rewrite the generated script to use avbctl instead of "python avbtool"
+sed -i "s|^python avbtool |./avbctl |" vbmeta/sign_vbmeta.sh
 cp work/config-unisoc/rsa4096_vbmeta.pem vbmeta/
 chmod +x vbmeta/*
-sudo rm -f /usr/bin/python /usr/bin/python3.6 /usr/bin/python3.6m /usr/local/bin/python
-sudo ln -sf /usr/bin/python2.7 /usr/bin/python
 cd work
 
 if [ -f "splloader.bin" ]; then
@@ -148,7 +149,7 @@ fi
 
 cd vbmeta
 ./sign_vbmeta.sh
-python padding.py
+python3 padding.py
 cp vbmeta-sign-custom.img ../output/vbmeta.img
 
 cd ../work

--- a/noavb.sh
+++ b/noavb.sh
@@ -1,11 +1,12 @@
 mkdir work
-busybox unzip -oq original.zip -d work
+# static 7zz replaces busybox unzip; 7zz exit code 1 = warnings only (archive still fully extracted), tolerate it like unzip did
+7zz x -y -bd -owork/ original.zip || [ "$?" -eq 1 ]
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
 tar xzvf avbtool.tgz -C vbmeta/
 mv work/vbmeta* vbmeta/keys/vbmeta.img
-busybox unzip -oq magisk.apk -d boot/zzz
+7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
 git clone https://github.com/TomKing062/vendor_sprd_proprietories-source_packimage.git
 cp -a vendor_sprd_proprietories-source_packimage/sign_image/v2/prebuilt/* work/

--- a/noavb_v3.sh
+++ b/noavb_v3.sh
@@ -4,7 +4,8 @@ mkdir work
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
-tar xzvf avbtool.tgz -C vbmeta/
+cp main/avbctl/avbctl vbmeta/
+chmod +x vbmeta/avbctl
 mv work/vbmeta* vbmeta/keys/vbmeta.img
 7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
@@ -26,10 +27,10 @@ cd ../../vbmeta/keys/
 mv sign_vbmeta.sh ../
 mv padding.py ../
 cd ../..
+# rewrite the generated script to use avbctl instead of "python avbtool"
+sed -i "s|^python avbtool |./avbctl |" vbmeta/sign_vbmeta.sh
 cp work/config/rsa4096_vbmeta.pem vbmeta/
 chmod +x vbmeta/*
-sudo rm -f /usr/bin/python /usr/bin/python3.6 /usr/bin/python3.6m /usr/local/bin/python
-sudo ln -sf /usr/bin/python2.7 /usr/bin/python
 cd work
 
 if [ -f "splloader.bin" ]; then
@@ -148,7 +149,7 @@ fi
 
 cd vbmeta
 ./sign_vbmeta.sh
-python padding.py
+python3 padding.py
 cp vbmeta-sign-custom.img ../output/vbmeta.img
 
 cd ../work

--- a/noavb_v3.sh
+++ b/noavb_v3.sh
@@ -1,11 +1,12 @@
 mkdir work
-busybox unzip -oq original.zip -d work
+# static 7zz replaces busybox unzip; 7zz exit code 1 = warnings only (archive still fully extracted), tolerate it like unzip did
+7zz x -y -bd -owork/ original.zip || [ "$?" -eq 1 ]
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
 tar xzvf avbtool.tgz -C vbmeta/
 mv work/vbmeta* vbmeta/keys/vbmeta.img
-busybox unzip -oq magisk.apk -d boot/zzz
+7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
 git clone https://github.com/TomKing062/vendor_sprd_proprietories-source_packimage.git
 cp -a vendor_sprd_proprietories-source_packimage/sign_image/v3/prebuilt/* work/

--- a/setup-7zz.sh
+++ b/setup-7zz.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# setup-7zz.sh - install a 7-Zip (7zz) binary that replaces busybox/unzip for
+# every archive extraction done by this repo (original.zip / magisk.apk).
+#
+# Sources are tried in order, and every candidate is verified to actually run
+# on the current system (catches glibc-incompatible builds) before acceptance:
+#
+#   1. official 7-Zip releases (github.com/ip7z/7zip): latest version, amd64
+#      (linux-x64) build, asset URL resolved through the GitHub API.
+#      Ships the fully static "7zzs" binary (preferred over "7zz").
+#   2. mcmilk/7-Zip-zstd nightly CI artifact, served by nightly.link:
+#      .../workflows/build/master/linux-clang-x64.zip (clang x64 build with
+#      zstd support; dynamically linked, so only used when source 1 fails).
+#
+# Only curl + tar and, as a bootstrap fallback, the python3 stdlib are used
+# (tar.xz / zip are unpacked without unzip).
+#
+# Usage: ./setup-7zz.sh [dest]    (dest defaults to /usr/local/bin/7zz)
+set -u
+
+DEST="${1:-/usr/local/bin/7zz}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+log() { printf 'setup-7zz: %s\n' "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+usable() { # does the candidate binary execute on this system?
+    "$1" i >/dev/null 2>&1
+}
+
+install_7zz() {
+    if [ "$(id -u)" = "0" ]; then
+        install -m 0755 "$1" "$DEST"
+    else
+        sudo install -m 0755 "$1" "$DEST"
+    fi
+    log "installed $("$DEST" i 2>/dev/null | head -n1 | sed 's/ : Copyright.*//') -> $DEST"
+}
+
+pick_and_install() { # $1 = dir that (recursively) holds candidate binaries
+    local dir="$1" bin
+    for bin in "$(find "$dir" -type f -name 7zzs -print -quit)" \
+               "$(find "$dir" -type f -name 7zz  -print -quit)"; do
+        [ -n "$bin" ] || continue
+        chmod +x "$bin" 2>/dev/null || true
+        if usable "$bin"; then
+            install_7zz "$bin"
+            return 0
+        fi
+        log "candidate $bin does not run on this system, skipping"
+    done
+    return 1
+}
+
+try_ip7z() { # official release: latest 7-Zip, linux-x64 (amd64), via GitHub API
+    log "trying official 7-Zip (ip7z/7zip) latest linux-x64 release via GitHub API"
+    local json="$WORK/ip7z.json" tarball="$WORK/7zip-linux-x64.tar.xz" url
+    local hdr=()
+    [ -n "${GITHUB_TOKEN:-}" ] && hdr=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    curl -fsSL --retry 3 ${hdr[@]+"${hdr[@]}"} -o "$json" \
+        "https://api.github.com/repos/ip7z/7zip/releases/latest" || return 1
+    url="$(grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]+"' "$json" \
+        | grep -oE 'https://[^"]+' | grep -E -- '-linux-x64\.tar\.xz$' | head -n 1)"
+    [ -n "$url" ] || { log "no linux-x64 asset found in latest ip7z/7zip release"; return 1; }
+    log "asset: $url"
+    curl -fsSL --retry 3 -o "$tarball" "$url" || return 1
+    mkdir -p "$WORK/ip7z"
+    if ! tar -xJf "$tarball" -C "$WORK/ip7z" 2>/dev/null; then
+        # tar without xz support (xz-utils missing) -> python3 stdlib handles .xz
+        python3 -c 'import sys,tarfile; tarfile.open(sys.argv[1]).extractall(sys.argv[2])' \
+            "$tarball" "$WORK/ip7z" || return 1
+    fi
+    pick_and_install "$WORK/ip7z" && return 0
+    return 1
+}
+
+try_mcmilk() { # nightly build artifact of mcmilk/7-Zip-zstd via nightly.link
+    log "trying mcmilk/7-Zip-zstd nightly artifact (linux-clang-x64.zip via nightly.link)"
+    local zip="$WORK/linux-clang-x64.zip"
+    curl -fsSL --retry 3 -o "$zip" \
+        "https://nightly.link/mcmilk/7-Zip-zstd/workflows/build/master/linux-clang-x64.zip" \
+        || return 1
+    mkdir -p "$WORK/mcmilk"
+    # the artifact is a zip - bootstrap-extract it with the python3 stdlib,
+    # since this repo deliberately no longer uses unzip
+    python3 -c 'import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])' \
+        "$zip" "$WORK/mcmilk" || return 1
+    pick_and_install "$WORK/mcmilk" && return 0
+    return 1
+}
+
+if [ -x "$DEST" ] && usable "$DEST"; then
+    log "$DEST already installed and working, nothing to do"
+    exit 0
+fi
+
+try_ip7z   && exit 0
+try_mcmilk && exit 0
+die "failed to obtain a working 7zz binary from all sources"

--- a/sign.sh
+++ b/sign.sh
@@ -1,11 +1,12 @@
 mkdir work
-busybox unzip -oq original.zip -d work
+# static 7zz replaces busybox unzip; 7zz exit code 1 = warnings only (archive still fully extracted), tolerate it like unzip did
+7zz x -y -bd -owork/ original.zip || [ "$?" -eq 1 ]
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
 tar xzvf avbtool.tgz -C vbmeta/
 mv work/vbmeta* vbmeta/keys/vbmeta.img
-busybox unzip -oq magisk.apk -d boot/zzz
+7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
 mv main/sign_avb.sh vbmeta/
 git clone https://github.com/TomKing062/vendor_sprd_proprietories-source_packimage.git

--- a/sign.sh
+++ b/sign.sh
@@ -4,7 +4,8 @@ mkdir work
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
-tar xzvf avbtool.tgz -C vbmeta/
+cp main/avbctl/avbctl vbmeta/
+chmod +x vbmeta/avbctl
 mv work/vbmeta* vbmeta/keys/vbmeta.img
 7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
@@ -25,10 +26,10 @@ cd ../../vbmeta/keys/
 mv sign_vbmeta.sh ../
 mv padding.py ../
 cd ../..
+# rewrite the generated script to use avbctl instead of "python avbtool"
+sed -i "s|^python avbtool |./avbctl |" vbmeta/sign_vbmeta.sh
 cp work/config-unisoc/rsa4096_vbmeta.pem vbmeta/
 chmod +x vbmeta/*
-sudo rm -f /usr/bin/python /usr/bin/python3.6 /usr/bin/python3.6m /usr/local/bin/python
-sudo ln -sf /usr/bin/python2.7 /usr/bin/python
 cd work
 
 if [ -f "splloader.bin" ]; then
@@ -184,7 +185,7 @@ fi
 
 cd vbmeta
 ./sign_vbmeta.sh
-python padding.py
+python3 padding.py
 cp vbmeta-sign-custom.img ../output/vbmeta.img
 
 cd ../work

--- a/sign_avb.sh
+++ b/sign_avb.sh
@@ -1,10 +1,10 @@
 #part_name signed_img img_to_sign [size_mb]
 PROP_FILE=$(mktemp)
-INFO_OUTPUT=$(python avbtool info_image --image $2)
+INFO_OUTPUT=$(./avbctl info_image --image $2)
 PARTITION_SIZE=$(echo "$INFO_OUTPUT" | grep -E "^Image size:" | awk '{print $(NF-1)}')
 echo "$INFO_OUTPUT" | grep "Prop:" > "$PROP_FILE"
 
-CMD="python avbtool add_hash_footer --image $3 --partition_name $1 --key rsa4096_$1.pem --algorithm SHA256_RSA4096"
+CMD="./avbctl add_hash_footer --image $3 --partition_name $1 --key rsa4096_$1.pem --algorithm SHA256_RSA4096"
 
 if [ -z "$PARTITION_SIZE" ] && [ -n "$4" ]; then
     PARTITION_SIZE=$(($4 * 1024 * 1024))

--- a/sign_v3.sh
+++ b/sign_v3.sh
@@ -1,11 +1,12 @@
 mkdir work
-busybox unzip -oq original.zip -d work
+# static 7zz replaces busybox unzip; 7zz exit code 1 = warnings only (archive still fully extracted), tolerate it like unzip did
+7zz x -y -bd -owork/ original.zip || [ "$?" -eq 1 ]
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
 tar xzvf avbtool.tgz -C vbmeta/
 mv work/vbmeta* vbmeta/keys/vbmeta.img
-busybox unzip -oq magisk.apk -d boot/zzz
+7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
 mv main/sign_avb.sh vbmeta/
 git clone https://github.com/TomKing062/vendor_sprd_proprietories-source_packimage.git

--- a/sign_v3.sh
+++ b/sign_v3.sh
@@ -4,7 +4,8 @@ mkdir work
 mkdir -p boot/zzz
 mkdir -p vbmeta/keys
 mkdir output
-tar xzvf avbtool.tgz -C vbmeta/
+cp main/avbctl/avbctl vbmeta/
+chmod +x vbmeta/avbctl
 mv work/vbmeta* vbmeta/keys/vbmeta.img
 7zz x -y -bd -oboot/zzz/ magisk.apk || [ "$?" -eq 1 ]
 mv main/boot_patch.sh boot/
@@ -25,10 +26,10 @@ cd ../../vbmeta/keys/
 mv sign_vbmeta.sh ../
 mv padding.py ../
 cd ../..
+# rewrite the generated script to use avbctl instead of "python avbtool"
+sed -i "s|^python avbtool |./avbctl |" vbmeta/sign_vbmeta.sh
 cp work/config/rsa4096_vbmeta.pem vbmeta/
 chmod +x vbmeta/*
-sudo rm -f /usr/bin/python /usr/bin/python3.6 /usr/bin/python3.6m /usr/local/bin/python
-sudo ln -sf /usr/bin/python2.7 /usr/bin/python
 cd work
 
 if [ -f "splloader.bin" ]; then
@@ -184,7 +185,7 @@ fi
 
 cd vbmeta
 ./sign_vbmeta.sh
-python padding.py
+python3 padding.py
 cp vbmeta-sign-custom.img ../output/vbmeta.img
 
 cd ../work


### PR DESCRIPTION
这次主要是两个大改动：
1.抛弃avbtool（硬py2约束），搞了一个在项目中功能等价的avbctl（来自https://github.com/Manatsu0721/avb_mini_signer，AI再加了点功能以符合实际需求），因此也移除了嵌套20.04的容器
2.把unzip替换成了通过github api从ip7z/7zip获取的最新版 -linux-x64.tar.xz版本得到的静态二进制文件（支持对使用压缩率更高的算法压缩的zip进行解压）

结果：处理resign之类的没啥问题,所花时间略微降低了10s，支持解压unzip不支持算法压缩的zip文件
